### PR TITLE
Add support for location attributes in Attio

### DIFF
--- a/src/connections/destinations/catalog/actions-attio/index.md
+++ b/src/connections/destinations/catalog/actions-attio/index.md
@@ -158,10 +158,9 @@ with both the domain and twitter handles above.
 
 ## Attribute types
 
-With the exception of location data, the Attio Action can write all other types of
-attribute to Attio. Below is an example of the format that each attribute must be; please
-note that you'll get validation failures if any of these are incorrect. To unset an
-attribute, you can also pass `null` as the value.
+The Attio Action can write all types of attribute to Attio. Below is an example of the
+format that each attribute must be; please note that you'll get validation failures if any
+of these are incorrect. To unset an attribute, you can also pass `null` as the value.
 
 | `type`               | Format                                                                                  | Example values                                              |
 |----------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------------------|
@@ -171,7 +170,7 @@ attribute, you can also pass `null` as the value.
 | `date`               | YYYY-MM-DD                                                                              | `"2023-09-28"`                                              |
 | `domain`             | `{domain}.{tld}`                                                                        | `"app.attio.com"`, `"www.example.com"`                      |
 | `email`              | A valid email address                                                                   | `"person@example.com"`                                      |
-| `location`           | *unsupported*                                                                           |                                                             |
+| `location`           | String with all valid address parts combined                                            | "1 Infinite Loop, Cupertino, CA, US"                        |
 | `number`             | Number, stored as a 64 bit float                                                        | `42.192`, `17`                                              |
 | `personal-name`      | Last name(s), First name(s) *(note the comma in the middle)*                            | `"Bloggs, Joe"`                                             |
 | `phone-number`       | [E.164 format](https://en.wikipedia.org/wiki/E.164), starting with `+...`               | `"+15558675309"`                                            |


### PR DESCRIPTION
### Proposed changes

Hi folks! We've recently added an address parser to the Attio API so we can now accept location data. Since all these attributes are cast down to strings, it accepts a string containing mixed location data and converts it back into structured data internally (it doesn't really matter about ordering of parts, or punctuation, these are stripped out when the parser runs).

Here's an example from the mappings we use for our Segment instance:

<img width="1763" alt="Screenshot 2023-11-27 at 09 40 14" src="https://github.com/attio/segmentio-segment-docs/assets/661795/d6896f0b-fc5e-4f20-b896-a40ffbea19ca">

Do you think there is any further guidance we should provide here?

### Merge timing

- ASAP once approved

<!--Refer to related PRs or issues: #1234 or 'Closes #1234'.
    Or paste full URLs to issues or pull requests in other Github projects -->
